### PR TITLE
ContactUsHelperImages

### DIFF
--- a/app/assets/javascripts/contacts.js
+++ b/app/assets/javascripts/contacts.js
@@ -1,0 +1,19 @@
+$(function () {
+  $('.itemNoLabel').on('mouseover', function(e) {
+    $('.helper-item')
+    .show()
+    .css({ opacity: 1, top: e.currentTarget.offsetTop - 510 - 20 })
+  })
+  $('.itemNoLabel').on('mouseout', function(e) {
+    $('.helper-item').css({ opacity: 0 }).hide()
+  })
+
+  $('.controlNoLabel').on('mouseover', function(e) {
+    $('.helper-control')
+      .show()
+      .css({ opacity: 1, top: e.currentTarget.offsetTop - 510 - 20 })
+  })
+  $('.controlNoLabel').on('mouseout', function(e) {
+    $('.helper-control').css({ opacity: 0 }).hide()
+  })  
+});

--- a/app/assets/stylesheets/contact.sass
+++ b/app/assets/stylesheets/contact.sass
@@ -5,12 +5,41 @@ form
   margin: 40px 80px
   padding: 20px
 
+  .helper-item
+    background: image-url("helper-item.jpg")
+
+  .helper-control
+    background-image: image-url("helper-control.jpg")
+
+  .helper
+    background-color: transparent
+    background-repeat: no-repeat
+    background-size: contain
+    display: none
+    position: absolute
+    width: 500px
+    height: 500px
+    margin: 0px auto
+    left: 0
+    right: 0
+    transition: .05s opacity ease-out
+    border: 1px solid #555555
+    box-shadow: 0 2px 14px rgba(0,0,0,.15), 0 0 0 0.5px rgba(0,0,0,.2)
+
   .section
     margin-bottom: 20px
 
   label
     display: block
     color: #555555
+
+  .itemNoLabel, .controlNoLabel
+    color: #555555
+    display: inline-block
+    text-align: left
+    font-size: 1.2em
+    margin-right: 5px
+    cursor: default
 
   .errors
     color: $red

--- a/app/views/contacts/new.haml
+++ b/app/views/contacts/new.haml
@@ -11,6 +11,9 @@
   For other inquiries please fill out the form below. We would love to answer your questions!
 
 = form_for(:comment, :url => contact_path) do |f|
+  .helper.helper-item
+  .helper.helper-control
+
   .section
     = f.label :subject
     = f.select :subject, options_for_select(Comment::SUBJECTS), include_blank: true
@@ -30,7 +33,9 @@
     .errors
       = @comment.errors[:email].to_sentence
   .section
-    = f.text_area :comments, :rows => 10, :cols => 70, :value => "Item #: [     ], Control #: [      ], Enter your comments here"
+    .itemNoLabel{:style => 'width: 100px'}Item No. [?] 
+    .controlNoLabel{:style => 'width: 100px'}Control No. [?]
+    = f.text_area :comments, :rows => 10, :cols => 70, :value => "   Item No.: [      ]" + "\n" + "Control No.: [      ]" + "\n" + "Enter your comments here"
     .errors
       = @comment.errors[:comments].to_sentence
 


### PR DESCRIPTION
Add the helper images for Item# and Control# to the Contact Us page. Split the comments helper text onto separate lines.