### PR TITLE
ProofofPurchase

### DIFF
--- a/app/assets/javascripts/replacements.js
+++ b/app/assets/javascripts/replacements.js
@@ -59,12 +59,10 @@ $(function () {
       $('#replacement_send_full_hardware_set_1').on('change', function(e) {
         $('.js-parts').find('input, button').prop('disabled', true);
         $('.js-part-information').text('Part Information')
-        $('.js-proof-of-purchase').text('Proof of Purchase')
       });
       $('#replacement_send_full_hardware_set_0').on('change', function(e) {
         $('.js-parts').find('input, button').prop('disabled', false);
         $('.js-part-information').text('Part Information (Required)')
-        $('.js-proof-of-purchase').text('Proof of Purchase (Required)')
       });
       $('.js-parts').find('input, button').prop('disabled', true);
     }

--- a/app/assets/stylesheets/replacements.sass
+++ b/app/assets/stylesheets/replacements.sass
@@ -63,3 +63,6 @@
   input[type="text"]:disabled
     background-color: #DDDDDD
     border: 2px solid #CCCCCC
+
+  input[type="file"]
+    padding: 4px

--- a/app/models/replacement.rb
+++ b/app/models/replacement.rb
@@ -39,6 +39,7 @@ class Replacement < ActiveType::Object
   validates :controlno, presence: true
   validates :itemno, presence: true
   validates :description, presence: true
+  validates :proof_of_purchase, presence: true
 
 
   after_save lambda { InfoMailer.replacement_email(self).deliver_now }

--- a/app/views/replacements/new.haml
+++ b/app/views/replacements/new.haml
@@ -95,6 +95,11 @@
       = f.text_field :description, :size => "60"
       .errors
         = @replacement.errors[:description].to_sentence
+    .section
+      = f.label :proof_of_purchase, value: "Proof of Purchase", :style => 'width: 120px'
+      = f.file_field :proof_of_purchase
+      .errors
+        = @replacement.errors[:proof_of_purchase].to_sentence      
 
   .send_full_hardware_set
     %p.errors
@@ -125,9 +130,6 @@
 
     %button.js-add-rows + Rows
 
-    %p
-      %legend.js-proof-of-purchase Proof of Purchase
-      = f.file_field :proof_of_purchase
 
   %fieldset
     %legend Comments (optional)


### PR DESCRIPTION
Require Proof of Purchase. Move out of the Parts section and up into the Purchase Information section.