### PR TITLE
Fix validation issues

### DIFF
--- a/app/assets/javascripts/replacements.js
+++ b/app/assets/javascripts/replacements.js
@@ -64,7 +64,14 @@ $(function () {
         $('.js-parts').find('input, button').prop('disabled', false);
         $('.js-part-information').text('Part Information (Required)')
       });
-      $('.js-parts').find('input, button').prop('disabled', true);
+
+      if ($('#replacement_send_full_hardware_set_0').is(':checked')) {
+        $('.js-parts').find('input, button').prop('disabled', false);
+        $('.js-part-information').text('Part Information (Required)');
+      }
+      else {
+        $('.js-parts').find('input, button').prop('disabled', true);
+      }
     }
 
     $('.js-add-rows').on('click', function (e) { e.preventDefault(); addRow(); });

--- a/app/assets/stylesheets/replacements.sass
+++ b/app/assets/stylesheets/replacements.sass
@@ -60,6 +60,11 @@
     input
       float:left
 
+  .requiredMsg
+    display: inline-block
+    margin-left: 15px
+    color: #555555
+
   input[type="text"]:disabled
     background-color: #DDDDDD
     border: 2px solid #CCCCCC

--- a/app/models/replacement.rb
+++ b/app/models/replacement.rb
@@ -39,7 +39,6 @@ class Replacement < ActiveType::Object
   validates :controlno, presence: true
   validates :itemno, presence: true
   validates :description, presence: true
-  validates :proof_of_purchase, presence: true
 
 
   after_save lambda { InfoMailer.replacement_email(self).deliver_now }

--- a/app/views/replacements/new.haml
+++ b/app/views/replacements/new.haml
@@ -106,8 +106,10 @@
     %p.errors
     = f.radio_button :send_full_hardware_set, "1", :checked => @replacement.send_full_hardware_set == true ? true : false
     = f.label :send_full_hardware_set_1, "Request for full hardware set only"
-    = f.radio_button :send_full_hardware_set, "0", :checked =>@replacement.send_full_hardware_set == false ? true : false
+    = f.radio_button :send_full_hardware_set, "0", :checked => @replacement.send_full_hardware_set == false ? true : false
     = f.label :send_full_hardware_set_0, "Request for missing parts and/or hardware"
+    .requiredMsg
+      (Required)
 
   %fieldset.js-parts
     %legend.js-part-information Part Information

--- a/app/views/replacements/new.haml
+++ b/app/views/replacements/new.haml
@@ -36,9 +36,10 @@
         = @replacement.errors[:address2].to_sentence
     .section{"style": "width: 100%; line-height: 30px;"}
       = f.label :address_type, value: "Address Type"
-      = f.select :address_type, options_for_select({"Select one" => nil, "Residential" => :residential, "Commercial" => :commercial})
+      = f.select :address_type, options_for_select({"Select one" => nil, "Residential" => :residential, "Commercial" => :commercial},@replacement.address_type)
       .errors
         = @replacement.errors[:address_type].to_sentence
+      
     .section
       = f.label :city
       = f.text_field :city, :size => "20"
@@ -103,9 +104,9 @@
 
   .send_full_hardware_set
     %p.errors
-    = f.radio_button :send_full_hardware_set, "1"
+    = f.radio_button :send_full_hardware_set, "1", :checked => @replacement.send_full_hardware_set == true ? true : false
     = f.label :send_full_hardware_set_1, "Request for full hardware set only"
-    = f.radio_button :send_full_hardware_set, "0"
+    = f.radio_button :send_full_hardware_set, "0", :checked =>@replacement.send_full_hardware_set == false ? true : false
     = f.label :send_full_hardware_set_0, "Request for missing parts and/or hardware"
 
   %fieldset.js-parts


### PR DESCRIPTION
Issue: Address Type and Send Hardware Set values are lost if there are form validation issues, forcing the customer to re-enter them before they can submit request. Fix: retain the previously entered values.
Issue: Customer may not have proof of purchase receipt if the item was a gift. Fix: don't validate customer has attached proof of purchase to request.