### PR TITLE
locally save contents of replacement requests as json files

### DIFF
--- a/app/controllers/replacements_controller.rb
+++ b/app/controllers/replacements_controller.rb
@@ -16,6 +16,15 @@ class ReplacementsController < ApplicationController
 
   def create
     if @replacement.valid?
+      if Rails.env == 'production'
+        # write email contents to file as json
+        replacement_json = @replacement.to_json
+        filename = "replacement_order_#{Time.now.to_i}"
+
+
+        File.write("/home/patrins/replacements/#{filename}.json", JSON.generate(replacement_json))
+      end
+      
       InfoMailer.replacement_email(@replacement).deliver_now
       redirect_to success_path
     else

--- a/app/models/replacement.rb
+++ b/app/models/replacement.rb
@@ -52,4 +52,30 @@ class Replacement
   validates :itemno, presence: true
   validates :description, presence: true
   validates :send_full_hardware_set, presence: true
+
+  # creates a json in the format provided
+  def to_json
+    {
+      name: name,
+      address1: address1,
+      address2: address2,
+      address_type: address_type,
+      city: city,
+      state: state,
+      zip: zip,
+      phone: phone,
+      email: email,
+
+      retailer: retailer,
+      purchase_date: purchase_date,
+      description: description,
+
+      itemno: itemno,
+      controlno: controlno,
+
+      send_full_hardware_set: send_full_hardware_set,
+      parts: parts,
+      comments: comments,
+    }
+  end
 end


### PR DESCRIPTION
Adds implementation where, whenever a replacement request is filled out on the Winsome website, the information from the request is locally saved as a JSON to a directory on ubuntu. 

The temporary directory currently being used is `/home/patrins/replacements/`.