### PR TITLE
Use date_field for Purchase Date

### DIFF
--- a/app/views/replacements/show.haml
+++ b/app/views/replacements/show.haml
@@ -89,7 +89,7 @@
         = @replacement.errors[:controlno].to_sentence
     .section
       = f.label :purchase_date, value: "Purchase Date"
-      = f.text_field :purchase_date, :size => "20"
+      = f.date_field :purchase_date, :value => @replacement.purchase_date
       .errors
         = @replacement.errors[:purchase_date].to_sentence
     .section


### PR DESCRIPTION
Standardize format of purchase date for json file - automated creation of pending replacement requests.