### PR TITLE
Require parts info

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -131,21 +131,12 @@ $(function () {
       }
     }
 
-    function requireToggleIsSelected(e) {
-      if (typeof $('#replacement_send_full_hardware_set_1:checked, #replacement_send_full_hardware_set_0:checked', '.replacements').val() == "undefined") {
-        e.stopPropagation();
-        e.preventDefault();
-        $('.send_full_hardware_set p.errors').text('Please select an option');
-      }
-    }
-
     $('.js-add-rows').on('click', function(e) {
       e.preventDefault();
       addRow();
     });
     prepopulatePartInformationFormValues();
     sendFullHardwareSetToggleHandlers();
-    $('.replacements').on('submit', requireToggleIsSelected)
   }
 });
 

--- a/app/models/replacement.rb
+++ b/app/models/replacement.rb
@@ -1,3 +1,4 @@
+require 'logger'
 class Replacement
   # Replacement does not extend ActiveRecord::Base.
   # It is an Active Model instead of an ActiveRecord Model.
@@ -53,6 +54,28 @@ class Replacement
   validates :itemno, presence: true
   validates :description, presence: true
   validates :send_full_hardware_set, presence: true
+
+  #validates :parts, presence: true, if: :parts_or_hardware?
+  #def parts_or_hardware?
+  #  (use block below but return true or false, but it didn't work)
+  # end
+
+  validate :parts_or_hardware
+  def parts_or_hardware
+    if send_full_hardware_set == "0"
+      tmpParts = JSON.parse(parts)
+      gotOne=false
+      tmpParts["letter"].each do |i,v|
+        if (tmpParts["letter"]["#{i}"].length > 0 || tmpParts["name"]["#{i}"].length > 0 || tmpParts["quantity"]["#{i}"].length > 0 || tmpParts["reason"]["#{i}"].length > 0) 
+          gotOne=true
+          break
+        end
+      end
+      if !gotOne
+        errors.add(:parts, "Please enter Part(s) Information")
+      end
+    end
+   end
 
   # creates a json in the format provided
   def to_json

--- a/app/models/replacement.rb
+++ b/app/models/replacement.rb
@@ -52,7 +52,7 @@ class Replacement
   validates :controlno, presence: true
   validates :itemno, presence: true
   validates :description, presence: true
-  validates :send_full_hardware_set, presence: true
+  validates :send_full_hardware_set, presence: { message: "Please select an option"}
 
   validate :parts_or_hardware
 

--- a/app/models/replacement.rb
+++ b/app/models/replacement.rb
@@ -1,4 +1,3 @@
-require 'logger'
 class Replacement
   # Replacement does not extend ActiveRecord::Base.
   # It is an Active Model instead of an ActiveRecord Model.
@@ -55,25 +54,20 @@ class Replacement
   validates :description, presence: true
   validates :send_full_hardware_set, presence: true
 
-  #validates :parts, presence: true, if: :parts_or_hardware?
-  #def parts_or_hardware?
-  #  (use block below but return true or false, but it didn't work)
-  # end
-
   validate :parts_or_hardware
+
   def parts_or_hardware
     if send_full_hardware_set == "0"
       tmpParts = JSON.parse(parts)
-      gotOne=false
       tmpParts["letter"].each do |i,v|
-        if (tmpParts["letter"]["#{i}"].length > 0 || tmpParts["name"]["#{i}"].length > 0 || tmpParts["quantity"]["#{i}"].length > 0 || tmpParts["reason"]["#{i}"].length > 0) 
-          gotOne=true
-          break
+        if !tmpParts["letter"]["#{i}"].empty? ||
+           !tmpParts["name"]["#{i}"].empty? ||
+           !tmpParts["quantity"]["#{i}"].empty? ||
+           !tmpParts["reason"]["#{i}"].empty?
+          return
         end
       end
-      if !gotOne
-        errors.add(:parts, "Please enter Part(s) Information")
-      end
+      errors.add(:parts, "Please enter Part(s) Information")
     end
    end
 

--- a/app/views/info_mailer/replacement_email.html.haml
+++ b/app/views/info_mailer/replacement_email.html.haml
@@ -69,7 +69,7 @@
 %div
   %h1 Parts
   %span.send_full_hardware_set
-    Send full hardware set only
+    Send full hardware set only:
     = @replacement.send_full_hardware_set == "1" ? "Yes" : "No"
   %table
     %tr

--- a/app/views/info_mailer/replacement_email.html.haml
+++ b/app/views/info_mailer/replacement_email.html.haml
@@ -70,7 +70,7 @@
   %h1 Parts
   %span.send_full_hardware_set
     Send full hardware set only
-    = @replacement.send_full_hardware_set ? "Yes" : "No"
+    = @replacement.send_full_hardware_set == "1" ? "Yes" : "No"
   %table
     %tr
       %th Letter

--- a/app/views/replacements/show.haml
+++ b/app/views/replacements/show.haml
@@ -1,4 +1,7 @@
 = form_for(:replacement, :url => replacement_path, :html => {:class => "replacements"}) do |f|
+  - if @replacement.errors.any?
+    %p.errors Please fix the errors below
+
   %p.bold **Due to COVID-19 our replacement parts have a current lead time of 7-10 business days to ship out. Please note there may be a delay in processing your request. We do apologize for this inconvenience.
 
   %p Contact your retailer for refunds or entire unit replacements.

--- a/app/views/replacements/show.haml
+++ b/app/views/replacements/show.haml
@@ -114,7 +114,8 @@
 
   %fieldset.js-parts
     %legend.js-part-information Part Information
-
+    .errors
+      = @replacement.errors[:parts].to_sentence
     %table.js-part-table{"data-parts": @replacement.parts.to_json}
       %tr
         %th Part Letter

--- a/app/views/replacements/show.haml
+++ b/app/views/replacements/show.haml
@@ -107,7 +107,8 @@
         = @replacement.errors[:proof_of_purchase].to_sentence
 
   .send_full_hardware_set
-    %p.errors
+    .errors
+      = @replacement.errors[:send_full_hardware_set].to_sentence
     = f.radio_button :send_full_hardware_set, "1", :checked => @replacement.send_full_hardware_set == "1"
     = f.label :send_full_hardware_set_1, "Request for full hardware set only"
     = f.radio_button :send_full_hardware_set, "0", :checked => @replacement.send_full_hardware_set == "0"


### PR DESCRIPTION
Require customer to include parts information in replacement request entry when they choose "Request for missing parts and/or hardware".

Please also see earlier comment.