### PR TITLE
limit log sizes to 50 Mb

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -73,4 +73,7 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+
+  # Limit log size to 50 Mb
+  config.logger = ActiveSupport::Logger.new(config.paths['log'].first, 1, 50 * 1024 * 1024)
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -102,6 +102,9 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
+  # Limit log size to 50 Mb
+  config.logger = ActiveSupport::Logger.new(config.paths['log'].first, 1, 50 * 1024 * 1024)
+
   # Inserts middleware to perform automatic connection switching.
   # The `database_selector` hash is used to pass options to the DatabaseSelector
   # middleware. The `delay` is used to determine how long to wait after a write


### PR DESCRIPTION
Golf, these changes were from the older version of rails. I've added them back here on ubuntu_test, and restarted rails. No errors on restart, sending a test email worked, so I assume all is good. 