### PR TITLE
replace COVID-19 verbiage with Supply Chain Issue message

### DIFF
--- a/app/views/replacements/show.haml
+++ b/app/views/replacements/show.haml
@@ -2,7 +2,7 @@
   - if @replacement.errors.any?
     %p.errors Please fix the errors below
 
-  %p.bold **Due to COVID-19 our replacement parts have a current lead time of 7-10 business days to ship out. Please note there may be a delay in processing your request. We do apologize for this inconvenience.
+  %p.bold **Due to supply chain issue, our replacement parts have a fulfillment lead time of 7-14 business days to ship out. We apologize for this inconvenience. Thank you for your patience.
 
   %p Contact your retailer for refunds or entire unit replacements.
 
@@ -10,7 +10,7 @@
     %li
       \- Free replacement parts provided within 60 days of purchase date.
     %li
-      \- Proof of purchase required from authorized retailer.
+      \- Proof of purchase required from an authorized retailer.
     %li
       \- Replacement parts ship within the U.S.A. and Canada only.
     %li


### PR DESCRIPTION
Remove COVID-19 from the replacement request header message. Reference the current supply chain issue. Increase leadtime days out to 14 for Canada.